### PR TITLE
Strip accents from accented characters

### DIFF
--- a/slugification.go
+++ b/slugification.go
@@ -5,11 +5,21 @@ package slugification
 import (
 	"strings"
 	"unicode"
+
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
 )
 
 // Returns a slugified string
 // Example: "Page Title" becomes "page-title"
 func Slugify(inputString string) string {
+
+	isMn := func(r rune) bool {
+		return unicode.Is(unicode.Mn, r) // Mn: nonspacing marks
+	}
+
+	t := transform.Chain(norm.NFD, transform.RemoveFunc(isMn), norm.NFC)
+
 	replaceChar := func(r rune) rune {
 		switch {
 		case unicode.IsLetter(r):
@@ -22,5 +32,8 @@ func Slugify(inputString string) string {
 			return -1
 		}
 	}
-	return strings.Map(replaceChar, inputString)
+
+	slug, _, _ := transform.String(t, strings.Map(replaceChar, inputString))
+
+	return slug
 }

--- a/slugification_test.go
+++ b/slugification_test.go
@@ -30,4 +30,10 @@ func TestSlugification(t *testing.T) {
 	if slugged != "1--3--5-2234x5420poopor264211dffme350" {
 		t.Errorf("slugged string is wrong: %v", slugged)
 	}
+	//String with tough accents
+	testString5 := "Árvíztűrő Tükörfúrógép"
+	slugged = slugification.Slugify(testString5)
+	if slugged != "arvizturo-tukorfurogep" {
+		t.Errorf("slugged string is wrong: %v", slugged)
+	}
 }


### PR DESCRIPTION
After the string map, we pass the result to transform.String which uses [normalization magic](https://blog.golang.org/normalization#TOC_10.) to remove the modifiers (accents etc) from the characters.  The intermediate variable slug is used so that transform.String's n and err results can be ignored.

I've included a test, checking that:

```
Árvíztűrő Tükörfúrógép
```

is transformed to:

```
arvizturo-tukorfurogep
```
